### PR TITLE
Added missing openssl dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,8 @@ recipe "phpmyadmin::mysql", "Creates the phpmyadmin-database and sets database p
 recipe "phpmyadmin::apache2", "Configures phpmyadmin to be used with apache2"
 recipe "phpmyadmin::nginx", "Configures phpmyadmin to be used with nginx"
 
+depends 'openssl'
+
 %w{ ubuntu debian centos redhat amazon scientific oracle fedora }.each do |os|
   supports os
 end


### PR DESCRIPTION
Without this, the following error occurred:

```
================================================================================
Recipe Compile Error in /home/jan/chef/cookbooks/phpmyadmin/recipes/default.rb
================================================================================

NameError
---------
uninitialized constant Opscode::OpenSSL

Cookbook Trace:
---------------
  /home/jan/chef/cookbooks/phpmyadmin/recipes/configuration.rb:1:in `from_file'
  /home/jan/chef/cookbooks/phpmyadmin/recipes/default.rb:3:in `from_file'

Relevant File Content:
----------------------
/home/jan/chef/cookbooks/phpmyadmin/recipes/configuration.rb:

  1>> ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
  2:  
  3:  # generate all passwords
  4:  node.set_unless[:phpmyadmin][:cfg][:blowfish_secret]          =   secure_password()
  5:  node.set_unless[:phpmyadmin][:cfg][:control_user_password]    =   secure_password()
  6:  
  7:  template "#{node[:phpmyadmin][:cfg][:cfg_path]}/config-db.php" do
  8:    source "phpmyadmin/config-db.php.erb"
  9:    owner "root"
 10:    group "root"
