### PR TITLE
Added .conf as apache_site was changed to look for this

### DIFF
--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -1,6 +1,6 @@
 include_recipe "apache2"
 
-link "#{node['apache']['dir']}/sites-available/phpmyadmin" do
+link "#{node['apache']['dir']}/sites-available/phpmyadmin.conf" do
     action :create
     to "#{node[:phpmyadmin][:apache2][:site_config]}"
 end


### PR DESCRIPTION
Using the latest apache2 cookbook fails as the apache_site expects the .conf to be there now.  